### PR TITLE
Add custom elements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .nyc_output
 coverage
 node_modules
+.vscode

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,4 @@
+{
+  "editor.formatOnSave": false,
+  "editor.formatOnPaste": false
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,0 @@
-{
-  "editor.formatOnSave": false,
-  "editor.formatOnPaste": false
-}

--- a/README.md
+++ b/README.md
@@ -208,6 +208,12 @@ Only `bibPath` is required.
 
     // Wrap bibliography in a div
     wrapBibliography: true,
+    
+    // Element that wraps bibliography contents
+    bibliographyContentsWrapper: "div",
+    
+    // Element that wraps bibliography entry
+    bibliographyEntryWrapper: "div"
 };
 ```
 

--- a/README.md
+++ b/README.md
@@ -200,11 +200,8 @@ Only `bibPath` is required.
     // (choose carefully to prevent collissions with other tokens)
     bibliographyMark: "[bibliography]",
 
-    // Replace bibliography title (h2)
-    bibliographyTitle: "Bibliography",
-
-    // Replace bibliography title (h2) classes
-    bibliographyTitleClasses: "bibliography-title",
+    // Replace bibliography title element
+    bibliographyTitle: '<h2 class="bibliography-title">Bibliography</h2>',
 
     // Wrap bibliography in a div
     wrapBibliography: true,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,13 +1,13 @@
 {
   "name": "@arothuis/markdown-it-biblatex",
-  "version": "0.1.0",
+  "version": "0.4.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@arothuis/markdown-it-biblatex",
-      "version": "0.1.0",
-      "license": "ISC",
+      "version": "0.4.0",
+      "license": "MIT",
       "dependencies": {
         "biblatex-csl-converter": "^2.0.4",
         "citeproc": "^2.4.62"
@@ -1596,9 +1596,9 @@
       }
     },
     "node_modules/json5": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.1.tgz",
-      "integrity": "sha512-1hqLFMSrGHRHxav9q9gNjJ5EXznIxGVO09xQRrwplcS8qs28pZ8s8hupZAmqDwZUmVZ2Qb2jnyPOWcDH8m8dlA==",
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
       "dev": true,
       "bin": {
         "json5": "lib/cli.js"
@@ -3807,9 +3807,9 @@
       "dev": true
     },
     "json5": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.1.tgz",
-      "integrity": "sha512-1hqLFMSrGHRHxav9q9gNjJ5EXznIxGVO09xQRrwplcS8qs28pZ8s8hupZAmqDwZUmVZ2Qb2jnyPOWcDH8m8dlA==",
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
       "dev": true
     },
     "linkify-it": {

--- a/src/index.js
+++ b/src/index.js
@@ -41,6 +41,12 @@ const DEFAULT_OPTIONS = {
 
     // Wrap bibliography in a div
     wrapBibliography: true,
+    
+    // Element that wraps bibliography contents
+    bibliographyContentsWrapper: "div",
+    
+    // Element that wraps bibliography entry
+    bibliographyEntryWrapper: "div"
 };
 
 function mdBibLatexPlugin(md, _options) {

--- a/src/index.js
+++ b/src/index.js
@@ -33,11 +33,8 @@ const DEFAULT_OPTIONS = {
     // (choose carefully to prevent collissions with other tokens)
     bibliographyMark: "[bibliography]",
 
-    // Replace bibliography title (h2)
-    bibliographyTitle: "Bibliography",
-
-    // Replace bibliography title (h2) classes
-    bibliographyTitleClasses: "bibliography-title",
+    // Replace bibliography title element
+    bibliographyTitle: '<h2 class="bibliography-title">Bibliography</h2>',
 
     // Wrap bibliography in a div
     wrapBibliography: true,

--- a/src/renderer.js
+++ b/src/renderer.js
@@ -3,7 +3,9 @@ function renderer(context) {
     const { 
         wrapBibliography, 
         bibliographyTitleClasses, 
-        bibliographyTitle 
+        bibliographyTitle,
+        bibliographyContentsWrapper,
+        bibliographyEntryWrapper,
     } = context.options;
 
     function reference(tokens, idx, options, env, slf) {
@@ -47,9 +49,17 @@ function renderer(context) {
         citeproc.updateItems(seen);
         const [_, contents] = citeproc.makeBibliography();
 
-        return '<div class="bibliography-contents">\n' 
+        if (bibliographyEntryWrapper !== "div") {
+            contents.forEach((content, idx) => {
+                contents[idx] = content
+                                .replace("<div", "<" + bibliographyEntryWrapper)
+                                .replace("</div", "</" + bibliographyEntryWrapper)
+            })
+        }
+
+        return `<${bibliographyContentsWrapper} class="bibliography-contents">\n` 
             + contents.join("")
-            + '</div>\n';
+            + `</${bibliographyContentsWrapper}>\n`;
     }
 
     function bibliographyClose(tokens, idx, options, env, slf) {

--- a/src/renderer.js
+++ b/src/renderer.js
@@ -2,7 +2,6 @@ function renderer(context) {
     const { citeproc } = context;
     const { 
         wrapBibliography, 
-        bibliographyTitleClasses, 
         bibliographyTitle,
         bibliographyContentsWrapper,
         bibliographyEntryWrapper,
@@ -29,7 +28,7 @@ function renderer(context) {
             rendered += '<div class="bibliography">\n';
         }
 
-        rendered += `<h2 class="${bibliographyTitleClasses}">${bibliographyTitle}</h2>\n`;
+        rendered += bibliographyTitle + "\n";
 
         return rendered;
     }

--- a/test/fixtures/select-bibliography-custom-contents-wrapper.html
+++ b/test/fixtures/select-bibliography-custom-contents-wrapper.html
@@ -1,0 +1,9 @@
+<p>A bibliography (Cohen, 1963) is only produced for
+the items cited (Susskind &#38; Hrabovsky, 2014).</p>
+<div class="bibliography">
+<h2 class="bibliography-title">Bibliography</h2>
+<section class="bibliography-contents">
+  <div class="csl-entry">Cohen, P. J. (1963). The independence of the continuum hypothesis. <i>Proceedings of the National Academy of Sciences</i>, <i>50</i>(6), 1143–1148.</div>
+  <div class="csl-entry">Susskind, L., &#38; Hrabovsky, G. (2014). <i>Classical mechanics: the theoretical minimum</i>. New York, NY: Penguin Random House.</div>
+</section>
+</div>

--- a/test/fixtures/select-bibliography-custom-entry-wrapper.html
+++ b/test/fixtures/select-bibliography-custom-entry-wrapper.html
@@ -1,0 +1,9 @@
+<p>A bibliography (Cohen, 1963) is only produced for
+the items cited (Susskind &#38; Hrabovsky, 2014).</p>
+<div class="bibliography">
+<h2 class="bibliography-title">Bibliography</h2>
+<div class="bibliography-contents">
+  <li class="csl-entry">Cohen, P. J. (1963). The independence of the continuum hypothesis. <i>Proceedings of the National Academy of Sciences</i>, <i>50</i>(6), 1143–1148.</li>
+  <li class="csl-entry">Susskind, L., &#38; Hrabovsky, G. (2014). <i>Classical mechanics: the theoretical minimum</i>. New York, NY: Penguin Random House.</li>
+</div>
+</div>

--- a/test/fixtures/select-bibliography-custom-title.html
+++ b/test/fixtures/select-bibliography-custom-title.html
@@ -1,7 +1,7 @@
 <p>A bibliography (Cohen, 1963) is only produced for
 the items cited (Susskind &#38; Hrabovsky, 2014).</p>
 <div class="bibliography">
-<h2 class="bibliography-title">Sources</h2>
+<h1>References</h1>
 <div class="bibliography-contents">
   <div class="csl-entry">Cohen, P. J. (1963). The independence of the continuum hypothesis. <i>Proceedings of the National Academy of Sciences</i>, <i>50</i>(6), 1143–1148.</div>
   <div class="csl-entry">Susskind, L., &#38; Hrabovsky, G. (2014). <i>Classical mechanics: the theoretical minimum</i>. New York, NY: Penguin Random House.</div>

--- a/test/integration.test.js
+++ b/test/integration.test.js
@@ -130,6 +130,32 @@ describe("markdown-it plug-in", function () {
             const expected = fixture("select-bibliography-no-wrap.html");
             expect(output).to.equal(expected);
         });
+
+        specify("Custom wrapper for bibliography contents", function () {
+            md.use(mdBiblatex, { 
+                bibPath: __dirname + "/fixtures/bibliography.bib",
+                bibliographyContentsWrapper: "section"
+            });
+
+            const input = fixture("select-bibliography.md");
+            const output = md.render(input);
+
+            const expected = fixture("select-bibliography-custom-contents-wrapper.html");
+            expect(output).to.equal(expected);
+        });
+
+        specify("Custom wrapper for bibliography entry", function () {
+            md.use(mdBiblatex, { 
+                bibPath: __dirname + "/fixtures/bibliography.bib",
+                bibliographyEntryWrapper: "li"
+            });
+
+            const input = fixture("select-bibliography.md");
+            const output = md.render(input);
+
+            const expected = fixture("select-bibliography-custom-entry-wrapper.html");
+            expect(output).to.equal(expected);
+        });
     });
 
     context("configuration errors", function () {

--- a/test/integration.test.js
+++ b/test/integration.test.js
@@ -92,23 +92,10 @@ describe("markdown-it plug-in", function () {
             expect(output).to.equal(expected);
         });
 
-        specify("custom classes for bibliography title", function () {
+        specify("custom bibliography title element", function () {
             md.use(mdBiblatex, { 
                 bibPath: __dirname + "/fixtures/bibliography.bib",
-                bibliographyTitleClasses: "sources",
-            });
-
-            const input = fixture("select-bibliography.md");
-            const output = md.render(input);
-            
-            const expected = fixture("select-bibliography-custom-classes.html");
-            expect(output).to.equal(expected);
-        });
-
-        specify("custom bibliography title", function () {
-            md.use(mdBiblatex, { 
-                bibPath: __dirname + "/fixtures/bibliography.bib",
-                bibliographyTitle: "Sources",
+                bibliographyTitle: "<h1>References</h1>",
             });
 
             const input = fixture("select-bibliography.md");


### PR DESCRIPTION
Adds custom elements support for bibliography contents and bibliography entries.
This gives better options for accessibility (which I wanted for my particular use case).

For example, this configuration:
```js
md.use(mdBiblatex, { 
  bibPath: __dirname + "/fixtures/bibliography.bib",
  bibliographyContentsWrapper: "ul",
  bibliographyEntryWrapper: "li"
});
```

Will result in the following output:
```html
<p>A bibliography (Cohen, 1963) is only produced for
the items cited (Susskind &#38; Hrabovsky, 2014).</p>
<div class="bibliography">
<h2 class="bibliography-title">Bibliography</h2>
<ul class="bibliography-contents">
  <li class="csl-entry">Cohen, P. J. (1963). The independence of the continuum hypothesis. <i>Proceedings of the National Academy of Sciences</i>, <i>50</i>(6), 1143–1148.</li>
  <li class="csl-entry">Susskind, L., &#38; Hrabovsky, G. (2014). <i>Classical mechanics: the theoretical minimum</i>. New York, NY: Penguin Random House.</li>
</ul>
</div>
```